### PR TITLE
fix: iOS で HLS 動画の再生速度を上げられないバグの修正

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -551,8 +551,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         result([FlutterError errorWithCode:@"unsupported_speed"
                                    message:@"Speed must be >= 0.0 and <= 2.0"
                                    details:nil]);
-    } else if ((speed > 1.0 && _player.currentItem.canPlayFastForward) ||
-               (speed < 1.0 && _player.currentItem.canPlaySlowForward)) {
+    } else if ((speed > 1.0) || (speed < 1.0)) {
         _playerRate = speed;
         result(nil);
     } else {


### PR DESCRIPTION
参考
https://github.com/jhomlala/betterplayer/issues/574#issuecomment-879657453